### PR TITLE
Add optimization on prometheus reconciliation loop

### DIFF
--- a/api/v1alpha1/mimirrules_types.go
+++ b/api/v1alpha1/mimirrules_types.go
@@ -69,6 +69,10 @@ type MimirRulesStatus struct {
 
 	// Error describes the last synchronization error
 	Error string `json:"error,omitempty"`
+
+	// Store concerned which prometheus rules are used in reference
+	// This allow a better change detection
+	RefRules []string `json:"refRules,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/internal/controller/mimirrules/mimirrules_controller.go
+++ b/internal/controller/mimirrules/mimirrules_controller.go
@@ -3,8 +3,10 @@ package mimirrules
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	prometheus "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -143,13 +145,41 @@ func (r *MimirRulesReconciler) reconcileOnPrometheusRuleChange(ctx context.Conte
 		return []reconcile.Request{}
 	}
 
+	// Check for existance of the rule
+	pr := &prometheus.PrometheusRule{}
+	err = r.Get(ctx, types.NamespacedName{Namespace: rule.GetNamespace(), Name: rule.GetName()}, pr)
+
 	requests := make([]reconcile.Request, len(allMimirRules.Items))
-	for i, item := range allMimirRules.Items {
-		requests[i] = reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Name:      item.GetName(),
-				Namespace: item.GetNamespace(),
-			},
+	// If Prometheus Rule is not found then it must have been deleted
+	if err != nil && errors.IsNotFound(err) {
+		// We update every MimirRule concerned by the delete Prometheus Rule
+		for i, item := range allMimirRules.Items {
+
+			namespaceAndName := rule.GetNamespace() + "_" + rule.GetName()
+			if slices.Contains(item.Status.RefRules, namespaceAndName) {
+
+				requests[i] = reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      item.GetName(),
+						Namespace: item.GetNamespace(),
+					}}
+			}
+		}
+	} else { // Prometheus rule have been updated or created, update only concerned rules
+		for i, item := range allMimirRules.Items {
+			promRulesList, _ := r.findPrometheusRulesFromLabels(ctx, item.Spec.Rules.Selectors)
+			namespaceAndName := rule.GetNamespace() + "_" + rule.GetName()
+			// If the updated/created rule affect the MimirRule then we request a reconcialition on it
+			// We check if the MimirRule match with the Prometheus Rule
+			// But also if the MimirRule previously match the Prometheus Rule (for example if the group change for the rule and not matching anymore)
+			if contains(promRulesList, rule.GetNamespace(), rule.GetName()) || slices.Contains(item.Status.RefRules, namespaceAndName) {
+				requests[i] = reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      item.GetName(),
+						Namespace: item.GetNamespace(),
+					},
+				}
+			}
 		}
 	}
 
@@ -185,4 +215,14 @@ func (r *MimirRulesReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			MaxConcurrentReconciles: 32,
 		}).
 		Complete(r)
+}
+
+// Check if the prometheus rule list has a matching rule with namespace and name combinaison
+func contains(pL *prometheus.PrometheusRuleList, namespace, name string) bool {
+	for _, p := range pL.Items {
+		if p.Name == name && p.Namespace == namespace {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/controller/mimirrules/rules.go
+++ b/internal/controller/mimirrules/rules.go
@@ -46,11 +46,15 @@ func (r *MimirRulesReconciler) syncRulesToRuler(ctx context.Context, mc *mimirap
 		return err
 	}
 
+	// Reset stored prometheus rules
+	mr.Status.RefRules = []string{}
+
 	// Synchronize each Rule on the Mimir Ruler
 	for namespace, ruleGroup := range unpackedRules {
 		if err := mc.CreateRuleGroupStr(ctx, namespace, ruleGroup); err != nil {
 			return err
 		}
+		mr.Status.RefRules = append(mr.Status.RefRules, namespace)
 	}
 
 	// Find the namespaces on Mimir that are NOT in our list of WANTED rules

--- a/internal/controller/mimirrules/rules.go
+++ b/internal/controller/mimirrules/rules.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	domain "github.com/AmiditeX/mimir-operator/api/v1alpha1"
 	"github.com/AmiditeX/mimir-operator/internal/controller/mimirapi"
@@ -56,6 +57,7 @@ func (r *MimirRulesReconciler) syncRulesToRuler(ctx context.Context, mc *mimirap
 		}
 		mr.Status.RefRules = append(mr.Status.RefRules, namespace)
 	}
+	sort.Strings(mr.Status.RefRules)
 
 	// Find the namespaces on Mimir that are NOT in our list of WANTED rules
 	// Those namespaces might have been created earlier by the operator, but the MimirRules selectors


### PR DESCRIPTION
Add a comparison to request updates to MimirRule only if they are affected by the updated Prometheus rules.

This should drastically reduce the operator workload when updating a Prometheus rule.